### PR TITLE
Add file ingestion connectors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ dependencies = [
     "langchain-mcp-adapters>=0.0.9",
     "langchain-deepseek>=0.1.3",
     "volcengine>=1.0.191",
+    "pdfplumber>=0.11.0",
+    "python-docx>=1.1.0",
+    "openpyxl>=3.1.2",
 ]
 
 [project.optional-dependencies]

--- a/src/ingestion/__init__.py
+++ b/src/ingestion/__init__.py
@@ -1,0 +1,13 @@
+from .file_loaders import (
+    extract_pdf_text,
+    extract_docx_text,
+    extract_xlsx_text,
+    ingest_file,
+)
+
+__all__ = [
+    "extract_pdf_text",
+    "extract_docx_text",
+    "extract_xlsx_text",
+    "ingest_file",
+]

--- a/src/ingestion/file_loaders.py
+++ b/src/ingestion/file_loaders.py
@@ -1,0 +1,53 @@
+import os
+from pathlib import Path
+
+import pdfplumber
+from docx import Document as DocxDocument
+from openpyxl import load_workbook
+
+from src.rag import Document, Chunk
+
+
+def extract_pdf_text(path: str) -> str:
+    """Extract plain text from a PDF file."""
+    text_parts: list[str] = []
+    with pdfplumber.open(path) as pdf:
+        for page in pdf.pages:
+            page_text = page.extract_text()
+            if page_text:
+                text_parts.append(page_text)
+    return "\n".join(text_parts)
+
+
+def extract_docx_text(path: str) -> str:
+    """Extract plain text from a Word (.docx) file."""
+    doc = DocxDocument(path)
+    return "\n".join(p.text for p in doc.paragraphs if p.text)
+
+
+def extract_xlsx_text(path: str) -> str:
+    """Extract cell values from an Excel (.xlsx) file as text."""
+    wb = load_workbook(path, data_only=True)
+    lines: list[str] = []
+    for ws in wb.worksheets:
+        for row in ws.iter_rows(values_only=True):
+            values = [str(cell) if cell is not None else "" for cell in row]
+            lines.append("\t".join(values))
+    return "\n".join(lines)
+
+
+def ingest_file(path: str) -> Document:
+    """Load a file and convert it into a Document for indexing."""
+    extension = Path(path).suffix.lower()
+    if extension == ".pdf":
+        content = extract_pdf_text(path)
+    elif extension == ".docx":
+        content = extract_docx_text(path)
+    elif extension == ".xlsx":
+        content = extract_xlsx_text(path)
+    else:
+        raise ValueError(f"Unsupported file type: {extension}")
+
+    filename = Path(path).name
+    chunk = Chunk(content=content, similarity=1.0)
+    return Document(id=filename, title=filename, chunks=[chunk])

--- a/tests/unit/ingestion/test_file_loaders.py
+++ b/tests/unit/ingestion/test_file_loaders.py
@@ -1,0 +1,55 @@
+import base64
+from pathlib import Path
+
+from src.ingestion import ingest_file
+
+PDF_B64 = (
+    "CiVQREYtMS40CjEgMCBvYmoKPDwgL1R5cGUgL0NhdGFsb2cgL1BhZ2VzIDIgMCBSID4+CmVuZG9iagoy"
+    "IDAgb2JqCjw8IC9UeXBlIC9QYWdlcyAvS2lkcyBbMyAwIFJdIC9Db3VudCAxID4+CmVuZG9iagozIDAg"
+    "b2JqCjw8IC9UeXBlIC9QYWdlIC9QYXJlbnQgMiAwIFIgL1Jlc291cmNlcyA8PCAvRm9udCA8PCAvRjEg"
+    "NCAwIFIgPj4gPj4gL01lZGlhQm94IFswIDAgMjAwIDIwMF0gL0NvbnRlbnRzIDUgMCBSID4+CmVuZG9i"
+    "ago0IDAgb2JqCjw8IC9UeXBlIC9Gb250IC9TdWJ0eXBlIC9UeXBlMSAvQmFzZUZvbnQgL0hlbHZldGlj"
+    "YSA+PgplbmRvYmoKNSAwIG9iago8PCAvTGVuZ3RoIDQ0ID4+CnN0cmVhbQpCVAovRjEgMTIgVGYKNzIg"
+    "NzIgVGQKKEhlbGxvIFBERikgVGoKRVQKZW5kc3RyZWFtCmVuZG9iagp4cmVmCjAgNgowMDAwMDAwMDAw"
+    "IDY1NTM1IGYgCjAwMDAwMDAwMTAgMDAwMDAgbiAKMDAwMDAwMDA2MSAwMDAwMCBuIAowMDAwMDAwMTEx"
+    "IDAwMDAwIG4gCjAwMDAwMDAyMjIgMDAwMDAgbiAKMDAwMDAwMDI5NiAwMDAwMCBuIAp0cmFpbGVyCjw8"
+    "IC9Sb290IDEgMCBSIC9TaXplIDYgPj4Kc3RhcnR4cmVmCjM3NQolJUVPRgo="
+)
+
+
+def write_pdf(path: Path) -> None:
+    data = base64.b64decode(PDF_B64)
+    path.write_bytes(data)
+
+
+def test_ingest_pdf(tmp_path):
+    pdf_path = tmp_path / "sample.pdf"
+    write_pdf(pdf_path)
+    doc = ingest_file(str(pdf_path))
+    assert "Hello PDF" in doc.chunks[0].content
+
+
+def test_ingest_docx(tmp_path):
+    from docx import Document as Doc
+
+    file_path = tmp_path / "sample.docx"
+    document = Doc()
+    document.add_paragraph("Hello DOCX")
+    document.save(file_path)
+
+    doc = ingest_file(str(file_path))
+    assert "Hello DOCX" in doc.chunks[0].content
+
+
+def test_ingest_xlsx(tmp_path):
+    from openpyxl import Workbook
+
+    wb = Workbook()
+    ws = wb.active
+    ws.append(["A", "B"])
+    ws.append(["1", "2"])
+    file_path = tmp_path / "sample.xlsx"
+    wb.save(file_path)
+
+    doc = ingest_file(str(file_path))
+    assert "A\tB" in doc.chunks[0].content


### PR DESCRIPTION
## Summary
- support ingestion of PDF, DOCX and XLSX files
- expose helper functions under `src.ingestion`
- include unit tests for the new file loaders
- add required dependencies

## Testing
- `black src/ingestion/*.py tests/unit/ingestion/test_file_loaders.py`
- `pytest -o addopts='' tests/unit/ingestion/test_file_loaders.py` *(fails: ModuleNotFoundError: No module named 'pdfplumber')*

------
https://chatgpt.com/codex/tasks/task_e_687dc73c2e58832e9c33c465a4a8f4f6