### PR TITLE
Add google and admin auth

### DIFF
--- a/src/server/user_tracker.py
+++ b/src/server/user_tracker.py
@@ -1,0 +1,7 @@
+signed_in_users: set[str] = set()
+
+def add_user(email: str) -> None:
+    signed_in_users.add(email)
+
+def list_users() -> list[str]:
+    return sorted(signed_in_users)

--- a/tests/unit/server/test_auth.py
+++ b/tests/unit/server/test_auth.py
@@ -1,0 +1,24 @@
+import pytest
+from fastapi.testclient import TestClient
+from src.server.app import app, ADMIN_TOKEN
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_record_user_and_admin_listing(client):
+    resp = client.post("/api/users/record", json={"email": "user@example.com"})
+    assert resp.status_code == 200
+    resp = client.post("/api/admin/login", json={"username": "admin@gmail.com", "password": "admin"})
+    assert resp.status_code == 200
+    token = resp.json()["token"]
+    assert token == ADMIN_TOKEN
+    resp = client.get("/api/admin/users", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    assert "user@example.com" in resp.json()
+
+
+def test_admin_login_fail(client):
+    resp = client.post("/api/admin/login", json={"username": "x", "password": "y"})
+    assert resp.status_code == 401

--- a/web/package.json
+++ b/web/package.json
@@ -83,6 +83,7 @@
     "unist-util-visit": "^5.0.0",
     "use-debounce": "^10.0.4",
     "use-stick-to-bottom": "^1.1.0",
+    "next-auth": "^4.24.5",
     "zod": "^3.24.3",
     "zustand": "^5.0.3"
   },

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -1,0 +1,25 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "../api/auth/[...nextauth]/route";
+import { redirect } from "next/navigation";
+
+export default async function AdminPage() {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user?.email !== "admin@gmail.com") {
+    redirect("/login");
+  }
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/admin/users`, {
+    headers: { Authorization: `Bearer admin-token` },
+    cache: "no-cache",
+  });
+  const users: string[] = await res.json();
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Signed in users</h1>
+      <ul className="list-disc ml-4">
+        {users.map((u) => (
+          <li key={u}>{u}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/web/src/app/api/auth/[...nextauth]/route.ts
+++ b/web/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,52 @@
+import NextAuth from "next-auth";
+import GoogleProvider from "next-auth/providers/google";
+import CredentialsProvider from "next-auth/providers/credentials";
+
+export const authOptions = {
+  providers: [
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+    }),
+    CredentialsProvider({
+      name: "Admin",
+      credentials: {
+        username: { label: "Email", type: "email" },
+        password: { label: "Password", type: "password" },
+      },
+      authorize(credentials) {
+        if (
+          credentials?.username === "admin@gmail.com" &&
+          credentials?.password === "admin"
+        ) {
+          return {
+            id: "admin",
+            name: "Admin",
+            email: "admin@gmail.com",
+            role: "admin",
+          };
+        }
+        return null;
+      },
+    }),
+  ],
+  callbacks: {
+    async signIn({ user }) {
+      if (user.email && user.email !== "admin@gmail.com") {
+        try {
+          await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/users/record`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ email: user.email }),
+          });
+        } catch (e) {
+          console.error("Failed to record user login", e);
+        }
+      }
+      return true;
+    },
+  },
+};
+
+const handler = NextAuth(authOptions);
+export { handler as GET, handler as POST };

--- a/web/src/app/chat/components/site-header.tsx
+++ b/web/src/app/chat/components/site-header.tsx
@@ -4,6 +4,7 @@
 import { StarFilledIcon, GitHubLogoIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { useTranslations } from 'next-intl';
+import { useSession, signOut, signIn } from "next-auth/react";
 
 import { LanguageSwitcher } from "~/components/deer-flow/language-switcher";
 import { NumberTicker } from "~/components/magicui/number-ticker";
@@ -12,6 +13,7 @@ import { env } from "~/env";
 
 export function SiteHeader() {
   const t = useTranslations('common');
+  const { data: session } = useSession();
 
   return (
     <header className="supports-backdrop-blur:bg-background/80 bg-background/40 sticky top-0 left-0 z-40 flex h-15 w-full flex-col items-center backdrop-blur-lg">
@@ -41,6 +43,9 @@ export function SiteHeader() {
               {env.NEXT_PUBLIC_STATIC_WEBSITE_ONLY &&
                 env.GITHUB_OAUTH_TOKEN && <StarCounter />}
             </Link>
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => session ? signOut() : signIn()}>
+            {session ? 'Sign out' : 'Sign in'}
           </Button>
         </div>
       </div>

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -10,6 +10,7 @@ import { NextIntlClientProvider } from 'next-intl';
 import { getLocale, getMessages } from 'next-intl/server';
 
 import { ThemeProviderWrapper } from "~/components/deer-flow/theme-provider-wrapper";
+import { SessionProviderWrapper } from "~/components/deer-flow/session-provider-wrapper";
 import { env } from "~/env";
 
 import { Toaster } from "../components/deer-flow/toaster";
@@ -49,7 +50,9 @@ export default async function RootLayout({
       </head>
       <body className="bg-app">
         <NextIntlClientProvider messages={messages}>
-          <ThemeProviderWrapper>{children}</ThemeProviderWrapper>
+          <SessionProviderWrapper>
+            <ThemeProviderWrapper>{children}</ThemeProviderWrapper>
+          </SessionProviderWrapper>
           <Toaster />
         </NextIntlClientProvider>
         {

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+import { signIn } from "next-auth/react";
+import { useState } from "react";
+import { Button } from "~/components/ui/button";
+
+export default function LoginPage() {
+  const [email, setEmail] = useState("admin@gmail.com");
+  const [password, setPassword] = useState("admin");
+
+  const handleAdmin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await signIn("credentials", {
+      username: email,
+      password,
+      callbackUrl: "/admin",
+    });
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-4 p-4">
+      <h1 className="text-2xl">Login</h1>
+      <Button onClick={() => signIn("google")}>Sign in with Google</Button>
+      <form onSubmit={handleAdmin} className="flex flex-col gap-2 w-60">
+        <input
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          type="email"
+          className="border p-2"
+          placeholder="Admin Email"
+        />
+        <input
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          type="password"
+          className="border p-2"
+          placeholder="Password"
+        />
+        <Button type="submit">Admin Login</Button>
+      </form>
+    </div>
+  );
+}

--- a/web/src/components/deer-flow/session-provider-wrapper.tsx
+++ b/web/src/components/deer-flow/session-provider-wrapper.tsx
@@ -1,0 +1,6 @@
+"use client";
+import { SessionProvider } from "next-auth/react";
+
+export function SessionProviderWrapper({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/web/src/env.js
+++ b/web/src/env.js
@@ -13,6 +13,8 @@ export const env = createEnv({
     NODE_ENV: z.enum(["development", "test", "production"]),
     AMPLITUDE_API_KEY: z.string().optional(),
     GITHUB_OAUTH_TOKEN: z.string().optional(),
+    GOOGLE_CLIENT_ID: z.string().optional(),
+    GOOGLE_CLIENT_SECRET: z.string().optional(),
   },
 
   /**
@@ -36,6 +38,8 @@ export const env = createEnv({
       process.env.NEXT_PUBLIC_STATIC_WEBSITE_ONLY === "true",
     AMPLITUDE_API_KEY: process.env.AMPLITUDE_API_KEY,
     GITHUB_OAUTH_TOKEN: process.env.GITHUB_OAUTH_TOKEN,
+    GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
+    GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially


### PR DESCRIPTION
## Summary
- add admin constants and user recording endpoints
- track users in memory
- support admin login listing users
- expose NextAuth API with Google SSO and admin credentials provider
- add login and admin pages
- show sign in/out button in header
- wrap app with session provider
- test new server auth logic

## Testing
- `make lint` *(fails: Failed to fetch https://pypi.org/simple/black/)*
- `make test` *(fails: Failed to fetch https://pypi.org/simple/black/)*

------
https://chatgpt.com/codex/tasks/task_e_687de556facc832e9f12ff5aa5d8c014